### PR TITLE
Prepare for Java 12: depend on a newer version of the AWS SDK 1.11.x …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-.idea/
-*.ipr
-*.iws
-*.iml
+# Build
 target
+
+# IntelliJ
+*.iml
+.idea

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-aws-maven

--- a/.idea/copyright/Apache_License__Version_2_0.xml
+++ b/.idea/copyright/Apache_License__Version_2_0.xml
@@ -1,9 +1,0 @@
-<component name="CopyrightManager">
-  <copyright>
-    <option name="notice" value="Copyright 2010-&amp;#36;today.year the original author or authors.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
-    <option name="keyword" value="Copyright" />
-    <option name="allowReplaceKeyword" value="" />
-    <option name="myName" value="Apache License, Version 2.0" />
-    <option name="myLocal" value="true" />
-  </copyright>
-</component>

--- a/.idea/dictionaries/bhale.xml
+++ b/.idea/dictionaries/bhale.xml
@@ -1,9 +1,0 @@
-<component name="ProjectDictionaryState">
-  <dictionary name="bhale">
-    <words>
-      <w>checkstyle</w>
-      <w>mkdirs</w>
-      <w>palo</w>
-    </words>
-  </dictionary>
-</component>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false">
-    <file url="file://$PROJECT_DIR$" charset="UTF-8" />
-  </component>
-</project>
-

--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,5 +1,0 @@
-<component name="DependencyValidationManager">
-  <state>
-    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
-  </state>
-</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -3,23 +3,17 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
-
-	<!-- We've moved this to a group that MainStreetHub has the ability to publish to. -->
-	<groupId>com.mainstreethub.build</groupId>
+	<!-- We've moved this to a group that Convey has the ability to publish to. -->
+	<groupId>com.getconvey.oss</groupId>
 	<artifactId>aws-maven</artifactId>
 	<packaging>jar</packaging>
-	<!-- The 5.0.0.RELEASE portion is the version that we forked from. -->
-	<version>5.0.0.RELEASE.MSH.2-SNAPSHOT</version>
+	<!-- The 5.0.0.RELEASE.MSH.1 portion is the version that we forked from. -->
+	<version>5.0.0.RELEASE.MSH.1.CONVEY.1-SNAPSHOT</version>
 	<name>Amazon Web Services S3 Maven Wagon Support</name>
 	<description>Standard Maven wagon support for s3:// urls</description>
 
 	<properties>
-		<amazonaws.version>1.9.8</amazonaws.version>
+		<amazonaws.version>1.11.550</amazonaws.version>
 		<junit.version>4.11</junit.version>
 		<logback.version>1.1.1</logback.version>
 		<mockito.version>1.9.5</mockito.version>
@@ -141,7 +135,7 @@
 		</plugins>
 	</build>
 
-	<url>https://github.com/mainstreethub/aws-maven</url>
+	<url>https://github.com/getconvey/aws-maven</url>
 
 	<inceptionYear>2007</inceptionYear>
 
@@ -154,9 +148,9 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git@github.com:mainstreethub/aws-maven</connection>
-		<developerConnection>scm:git:git@github.com:mainstreethub/aws-maven</developerConnection>
-		<url>https://github.com/mainstrethub/aws-maven</url>
+		<connection>scm:git:git@github.com:getconvey/aws-maven</connection>
+		<developerConnection>scm:git:git@github.com:getconvey/aws-maven</developerConnection>
+		<url>https://github.com/getconvey/aws-maven</url>
 	</scm>
 
 	<organization>


### PR DESCRIPTION
…which doesn't require JAXB to run (see https://github.com/aws/aws-sdk-java/commit/ba4a6a4ce49201ac73ad8ba89967c756a134a868) so that this is backward and forward compatible with Java 8 - 12+; re-home the project so that we can release it.